### PR TITLE
WIP: Functional relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv.bak/
 
 *.swp
 pip-wheel-metadata
+
+# IDE stuff
+/.vscode

--- a/chitanda/modules/relay.py
+++ b/chitanda/modules/relay.py
@@ -89,7 +89,7 @@ def _(listener, contents, source):
                 f'<@!?{mention.id}>', f'@{mention.display_name}', contents
             )
 
-        attachments = [a['url'] for a in source.raw.attachments]
+        attachments = [a.url for a in source.raw.attachments]
 
         return (
             (source.raw.author.display_name, c)

--- a/chitanda/modules/relay.py
+++ b/chitanda/modules/relay.py
@@ -5,6 +5,8 @@ from functools import singledispatch
 from chitanda.config import config
 from chitanda.listeners import DiscordListener, IRCListener
 from chitanda.util import get_listener
+from discord import Webhook, AsyncWebhookAdapter
+import aiohttp
 
 logger = logging.getLogger(__name__)
 
@@ -128,4 +130,8 @@ async def _(listener, bot, target, author, message):
     For Discord, relay the message using a webhook. Requires server admin to
     configure a webhook endpoint.
     """
-    pass  # Use webhook.
+    async with aiohttp.ClientSession() as session:
+        webhook = Webhook.from_url(
+            config['discord_webhook_url'], adapter=AsyncWebhookAdapter(session)
+        )
+        await webhook.send(message, username=author)

--- a/chitanda/modules/relay.py
+++ b/chitanda/modules/relay.py
@@ -91,10 +91,13 @@ def _(listener, contents, source):
 
         attachments = [a.url for a in source.raw.attachments]
 
-        return (
-            (source.raw.author.display_name, c)
-            for c in [contents, *attachments]
-        )
+        if contents:
+            return (
+                (source.raw.author.display_name, c)
+                for c in [contents, *attachments]
+            )
+        else:
+            return ((source.raw.author.display_name, c) for c in attachments)
 
     return ((None, contents),)
 

--- a/chitanda/util.py
+++ b/chitanda/util.py
@@ -49,6 +49,7 @@ class Message:
 
 class Response:
     def __init__(self, bot, listener, target, contents):
+        self.bot = bot
         self.listener = listener
         self.target = target
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ pytest-asyncio = "^0.10.0"
 pytest-cov = "^2.7"
 sphinx_rtd_theme = "^0.4.3"
 
+[tool.black]
+line-length = 79
+target-version = ['py37']
+skip-string-normalization = 1
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"


### PR DESCRIPTION
Relay between Discord/IRC works.

## Missing features before I consider this ready for merge
**Better documentation**
Currently there doesn't exist any documentation about the relay and its configuration requirements.
There was also a new config key introduced, `discord_webhook_url`, to relay messages to Discord.
This needs to be documented before the merge.

**Bugs that need to be fixed**
There is a bug where if a Discord user runs a command, the module responds with the Discord user's ID and not their display name.

```
[15:12] goats2k: .np
[15:12] BOT Benny: 155023073886601216 is now playing Vision by GLXY from Vision EP
```

There's another one where module names are translated from their short-hand alias names to the full name of the module when the message is being relayed.

In hindsight, I realized that I should probably make individual issues for these but w/e.
